### PR TITLE
Some revisions

### DIFF
--- a/e2.bib
+++ b/e2.bib
@@ -713,6 +713,18 @@ title = {{The Old and Thee, uh, New}},
 volume = {15},
 year = {2004}
 }
+
+@article{depaulo2003cues,
+  title={Cues to Deception},
+  author={DePaulo, Bella M and Lindsay, James J and Malone, Brian E and Muhlenbruck, Laura and Charlton, Kelly and Cooper, Harris},
+  journal={Psychological Bulletin},
+  volume={129},
+  number={1},
+  pages={74},
+  year={2003},
+  publisher={American Psychological Association}
+}
+
 @article{Bond2006,
 abstract = {We analyze the accuracy of deception judgments, synthesizing research results from 206 documents and 24,483 judges. In relevant studies, people attempt to discriminate lies from truths in real time with no special aids or training. In these circumstances, people achieve an average of 54{\%} correct lie-truth judgments, correctly classifying 47{\%} of lies as deceptive and 61{\%} of truths as nondeceptive. Relative to cross-judge differences in accuracy, mean lie-truth discrimination abilities are nontrivial, with a mean accuracy d of roughly .40. This produces an effect that is at roughly the 60th percentile in size, relative to others that have been meta-analyzed by social psychologists. Alternative indexes of lie-truth discrimination accuracy correlate highly with percentage correct, and rates of lie detection vary little from study to study. Our meta-analyses reveal that people are more accurate in judging audible than visible lies, that people appear deceptive when motivated to be believed, and that individuals regard their interaction partners as honest. We propose that people judge others' deceptions more harshly than their own and that this double standard in evaluating deceit can explain much of the accumulated literature.},
 author = {Bond, Charles F and DePaulo, Bella M},

--- a/e2.bib
+++ b/e2.bib
@@ -36,6 +36,13 @@ BibTeX export options can be customized via Options -> BibTeX in Mendeley Deskto
   publisher={Public Library of Science}
 }
 
+
+@Book{frankfurt05,
+  author = 	 {Harry G Frankfurt},
+  title = 	 {On Bullshit},
+  publisher = 	 {Princeton University Press},
+  year = 	 2005}
+
 === NEW STUFF ABOVE HERE
 
 @article{Arciuli2010,

--- a/e2b.tex
+++ b/e2b.tex
@@ -13,7 +13,7 @@
 
 \newcommand*{\smex}[1]{\textit{#1}} % 'small example'
 \newcommand*{\spex}[1]{``{#1}''} % 'spoken example'
-
+\newcommand*{\citegen}[1]{\citeauthor{#1}'s \citeyear{#1}}
 
 
 \title{Contextual effects on online pragmatic inferences.}
@@ -51,11 +51,11 @@ Disfluencies in speech are not merely incidental.  Speakers are more disfluent w
 %% get your citations right!  Arnold et al. (2003) is comprehension
 In this way, disfluencies provide paralinguistic `cues' about the content of a speaker's message.
 Research has shown that listeners can, and do, exploit these cues to make predictions about upcoming speech.
-For example, following a disfluency, they are more likely to predict the introduction of a new object into the discourse, as indexed by visual world eye movements \citep{Arnold2004}, and less likely to have difficulty integrating an unpredictable word into its context, as shown by a reduction in the N400~ERP component \citep{Corley2007}.
+For example, following a disfluency, they are more likely to predict the introduction of a new object into the discourse, as shown by visual world eye movements \citep{Arnold2004}, and less likely to have difficulty integrating an unpredictable word into its context, as indexed by a reduction in the N400~ERP component \citep{Corley2007}.
 
 Evidence from a series of eyetracking experiments suggests that predictions like these are sensitive to context.
 \citet{Arnold2007} asked participants to click on depictions of easy-to-name (ice-cream) or harder-to-name (abstract symbol) items in response to auditory instructions.
-Where the instructions were disfluent, participants were more likely to fixate harder-to-name items during an ambiguous colour adjective which preceded the item name.
+Where the instructions were disfluent, participants were more likely to fixate harder-to-name items before they heard the item name.
 Importantly, these fixation biases were modulated when participants were told that the speaker had object agnosia, and hence might be presumed to have difficulty naming easy-to-name items.
 The fact that a prediction that a hard-to-name item will follow a disfluency can be modulated by contextual information suggests that on encountering a disfluency, participants are not merely making a stochastic prediction about what might be mentioned next.
 Instead, they are actively modelling the speaker in order to account for the disfluency encountered and make situation-specific predictions.
@@ -70,13 +70,16 @@ Disfluency may affect what listeners think they are about to hear, but it has no
 However, a parallel literature shows that disfluency may also have pragmatic effects.
 %
 %FO(A)K; other pragmatics; lying; Jia \ra{}question:  Now we're talking about \emph{pragmatic} effects, is there evidence of speaker modelling?
-For example, \citet{Brennan1995} played listeners' answers to general knowledge questions which had been obtained during a production study.
+For example, participants in \citegen{Brennan1995} study were played recordings of answers to general knowledge questions which had been obtained during a production study.
 The answers were digitally edited and were sometimes preceded by either a silent pause, or a filler.
-Listeners in this study rated the answers as being less likely to be correct when the recorded answers were preceded by silence or fillers.
-In this study, listeners' interpretations of a spoken message depend on the manner in which it is delivered \citep[see also][]{Swerts2005}.
+Participants rated the answers as being less likely to be correct when the recorded answers were preceded by silence or fillers.
+In other words, listeners' interpretations of a spoken message directly depended on the manner in which it was delivered \citep[see also][]{Swerts2005}.
+
+%%%%%%%%%%%% NEEDS FIXED FROM HERE
 
 In \citeauthor{Brennan1995}'s study, disfluency affects the `Feeling of Another's Knowing (FOAK)', presumably because it is perceived to be more effortful to retrieve answers of which one is uncertain, and therefore more likely to result in disfluency.
-Another pragmatic effect which is often associated with effort is that of lying: the increased cognitive load involved in formulating and uttering a lie is often suggested as resulting in liars providing verbal and non-verbal cues to deception \citep{Zuckerman1981, DePaulo2003}.
+Another pragmatic effect which is often associated with effort is that of lying.
+The increased cognitive load involved in formulating and uttering a lie is often suggested as resulting in liars providing verbal and non-verbal cues to deception \citep{Zuckerman1981,depaulo2003cues}.
 Listeners' interpretations of deception appear to be sensitive to these cues accordingly: \citeauthor{Zuckerman1981} found hesitations in speech to be reliably associated with a perception of dishonesty, in both judgments made by speakers about themselves, and in judgments made about another speaker.
 
 This pragmatic effect of speaker disfluency has, until recently, been evidenced only in offline measures of judgement, such as a post-hoc assessment of a speaker's confidence or honesty. 

--- a/e2b.tex
+++ b/e2b.tex
@@ -13,6 +13,7 @@
 
 \newcommand*{\smex}[1]{\textit{#1}} % 'small example'
 \newcommand*{\spex}[1]{``{#1}''} % 'spoken example'
+\newcommand*{\term}[1]{\emph{#1}} % introducing a new term
 \newcommand*{\citegen}[1]{\citeauthor{#1}'s \citeyear{#1}}
 
 
@@ -72,23 +73,42 @@ However, a parallel literature shows that disfluency may also have pragmatic eff
 %FO(A)K; other pragmatics; lying; Jia \ra{}question:  Now we're talking about \emph{pragmatic} effects, is there evidence of speaker modelling?
 For example, participants in \citegen{Brennan1995} study were played recordings of answers to general knowledge questions which had been obtained during a production study.
 The answers were digitally edited and were sometimes preceded by either a silent pause, or a filler.
-In line with the suggestion that speakers use disfluency to manage difficulty in retrieving information \citep{Smith1993}, participants rated the answers as being less likely to be correct when the recorded answers were preceded by silence or fillers.
-In contrast to studies of expectation following disfluency, this study shows that listeners' interpretations of a spoken message directly depend on the manner in which it is delivered \citep[see also][]{Swerts2005}.
+In line with the suggestion that speakers use disfluency to manage difficulty in retrieving information \citep{Smith1993}, participants rated the answers as being less likely to be correct when the recorded answers were preceded by silence or fillers:
+In other words, their interpretations, rather than simply predictions, of the utterances they heard were directly affected by disfluency \citep[see also][]{Swerts2005}.
+Listeners faced with disfluency had less confidence in the speaker's knowledge (a weaker ``Feeling of Another's Knowing'', or FOAK), and therefore in the factual correctness of what was being said.
+
+%%% NB I couldn't find much evidence of "other pragmatic" effects.  I
+%%% do seem to recall some social psych papers talking about
+%%% disfluency as hedging; would be great if we could find those
+
+As well as producing language about which they have little confidence, speakers can easily produce language which they know to be false.
+This form of lying \citep[see][for another]{frankfurt05} is often associated with cognitive effort.
+According to this view, the increased load involved in formulating and uttering a lie may lead speakers to provide verbal and non-verbal cues to deception, including disfluency \citep{Zuckerman1981,depaulo2003cues}.
+% note careful phrasing above so as not to contradict Jia :)
+Listeners' interpretations appear to be sensitive to these cues: \citet{Zuckerman1981} found hesitations in speech to be reliably associated with a perception of dishonesty, in both judgments made by speakers about themselves, and judgments made about another speaker.
 
 
-%%%%%%%%%%%% NEEDS FIXED FROM HERE
-Another pragmatic effect which is often associated with effort is that of lying.
-The increased cognitive load involved in formulating and uttering a lie is often suggested as resulting in liars providing verbal and non-verbal cues to deception \citep{Zuckerman1981,depaulo2003cues}.
-Listeners' interpretations of deception appear to be sensitive to these cues accordingly: \citeauthor{Zuckerman1981} found hesitations in speech to be reliably associated with a perception of dishonesty, in both judgments made by speakers about themselves, and in judgments made about another speaker.
+In both FOAK and lying research, the proposed mechanism by which the interpretation of what is said is affected by disfluency is via \term{speaker modelling}:
+By reverse inference, disfluency is a symptom of cognitive difficulty, and cognitive difficulty is the consequence of limited knowledge (FOAK) or of inventing a situation (lying).
+To conclude that the speaker is lying requires reasoning about his or her cognitive state.
+However, listeners may in fact not reason in this way:
+Instead, they may heuristically associate certain aspects of spoken performance with lying, perhaps as a consequence of repeated exposure.
 
-This pragmatic effect of speaker disfluency has, until recently, been evidenced only in offline measures of judgement, such as a post-hoc assessment of a speaker's confidence or honesty. 
-However, recent research by \citeauthor{Loy2016} has helped to illuminate the time-course of this effect, showing that the bias towards interpreting disfluency as a cue to deception is apparent from the early stages of reference comprehension. 
-In \citet{Loy2016}, subjects engaged in what was posed as a `lie detection game', in which listeners were tasked to make implicit judgments about whether a speaker is being deceitful or not in indicating the location of a reward.
-Utterances were presented as either fluent or disfluent (``The treasure is behind [the]/[thee---uh---] \textless referent\textgreater .'').
-In a visual world eye-tracking paradigm, listeners signalled their assessment of a speaker's honesty by clicking on one of two objects (the referent and a distractor) - interpreting an utterance as honest would result in a click on the referent, and as dishonest a click on the distractor.
-\citeauthor{Loy2016} showed how listeners' pragmatic judgments about a speaker's honesty are influenced by the manner of utterance delivery during the online processing of speech.
-Subjects' eye- and mouse-movements displayed a bias toward the referred-to object for fluent utterances, and to the distractor object for disfluent utterances. 
-This bias listeners display towards interpreted speaker-disfluency as a cue to deception shows evidence of an ability to integrate information about utterance delivery and alter the global interpretation of an utterance during the moment-to-moment processing of speech.
+%%% this para needs some TLC
+One reason for believing that the association between disfluency and lying is heuristically calculated is evidence from \citet{Loy2016}, which highlights the speed at which pragmatic interpretations are made.
+\citeauthor{Loy2016}'s study was framed as a treasure hunting game, in which listeners were asked to guess the location of a reward by clicking on one of two depicted objects in each trial.
+Participants were told that the recorded speaker would be dishonest half of the time, and the recordings which indicated the location of the treasure were either fluent or disfluent (\spex{The treasure is behind [the]/[thee---uh---] \textless referent\textgreater}).
+Participants' judgements of the speaker's honesty in each trial were implictly measured by examining which of the two objects they clicked:
+Clicking on the named object corresponded to a judgement that the speaker was telling the truth, whereas a click on the other object meant that the speaker was thought to be lying.
+In line with previous research \citep{Zuckerman1981},  participants were less likely to click on the named object following disfluent utterances (and instead, tended to click on the object which had not been mentioned).
+Importantly, eye- and mouse-tracking records showed that this effect emerged as soon as it became clear which of the two objects was being named:
+In other words, participants' pragmatic judgements were shown to be influenced by disfluency at the earliest detectable moment.
+If speaker modelling is occurring, any inferences regarding the cause of a given disfluency would have to have been made very fast.
+Moreover, the evidence suggests that, in cases where disfluency might modulate listeners' predictions, contextual inferences are limited to more global factors which would affect the speaker throughout a discourse \citep{Arnold2007}.
+
+However, the automatic association of disfluency with dishonesty would be counterproductive in real human interactions.
+Moreover, since disfluency has been shown to index (at least) uncertainty as well as lying, there would at least have to be some heuristic to determine which interpretation was sensible.
+SO WE NEED TO DO AN EXPERIMENT\ldots
 
 %speaker-modelling in pragmatics? evidence?
 

--- a/e2b.tex
+++ b/e2b.tex
@@ -72,12 +72,11 @@ However, a parallel literature shows that disfluency may also have pragmatic eff
 %FO(A)K; other pragmatics; lying; Jia \ra{}question:  Now we're talking about \emph{pragmatic} effects, is there evidence of speaker modelling?
 For example, participants in \citegen{Brennan1995} study were played recordings of answers to general knowledge questions which had been obtained during a production study.
 The answers were digitally edited and were sometimes preceded by either a silent pause, or a filler.
-Participants rated the answers as being less likely to be correct when the recorded answers were preceded by silence or fillers.
-In other words, listeners' interpretations of a spoken message directly depended on the manner in which it was delivered \citep[see also][]{Swerts2005}.
+In line with the suggestion that speakers use disfluency to manage difficulty in retrieving information \citep{Smith1993}, participants rated the answers as being less likely to be correct when the recorded answers were preceded by silence or fillers.
+In contrast to studies of expectation following disfluency, this study shows that listeners' interpretations of a spoken message directly depend on the manner in which it is delivered \citep[see also][]{Swerts2005}.
+
 
 %%%%%%%%%%%% NEEDS FIXED FROM HERE
-
-In \citeauthor{Brennan1995}'s study, disfluency affects the `Feeling of Another's Knowing (FOAK)', presumably because it is perceived to be more effortful to retrieve answers of which one is uncertain, and therefore more likely to result in disfluency.
 Another pragmatic effect which is often associated with effort is that of lying.
 The increased cognitive load involved in formulating and uttering a lie is often suggested as resulting in liars providing verbal and non-verbal cues to deception \citep{Zuckerman1981,depaulo2003cues}.
 Listeners' interpretations of deception appear to be sensitive to these cues accordingly: \citeauthor{Zuckerman1981} found hesitations in speech to be reliably associated with a perception of dishonesty, in both judgments made by speakers about themselves, and in judgments made about another speaker.


### PR DESCRIPTION
Hi Jo,

predictably I didn't get as much time on this as I wanted -- so mainly small edits, and then an attempt to pull the "next" bit in the right direction.  Still not perfect -- we're mentioning evidence against speaker-modelling once early (prediction stuff: Arnold expt 3, dogs barking, etc.) and once late (aren't Jia's participants quick to make pragmatic judgements?).  See what you think, there may not be a neat way out of this.  Would be good to find some more pragmatic evidence (and some more lie evidence) too -- especially lying, where everything is predicated on two references(!)  Good luck, and let me know how you get on...  (the odd comment in the .tex too)